### PR TITLE
Fix a trivial typo in status codes

### DIFF
--- a/transmission-daemon@patapon.info/extension.js
+++ b/transmission-daemon@patapon.info/extension.js
@@ -48,7 +48,7 @@ const TransmissionStatus = {
     CHECK: 2,
     DOWNLOAD_WAIT: 3,
     DOWNLOAD: 4,
-    SEED_WAIT: 6,
+    SEED_WAIT: 5,
     SEED: 6
 }
 


### PR DESCRIPTION
The SEED_WAIT code was the same as the SEED one in the TransmissionStatus enum (or whatever that js structure is :) ) and it doesn't comply with the transmisson codes.
