### PR TITLE
Fix log spam from clutter

### DIFF
--- a/transmission-daemon@patapon.info/extension.js
+++ b/transmission-daemon@patapon.info/extension.js
@@ -1169,7 +1169,8 @@ const TorrentsControls = new Lang.Class({
 
         this.ctrl_btns = new St.BoxLayout({vertical: false,
                                            style_class: 'torrents-controls'});
-        this.ctrl_info = new St.Label({style_class: 'torrents-controls-text'});
+        this.ctrl_info = new St.Label({style_class: 'torrents-controls-text', 
+                                       text: ''});
         this.ctrl_info.add_style_pseudo_class("inactive");
 
 


### PR DESCRIPTION
If the text attribute is not there, clutter will often complain about it, leading to spam on every update. This change fixes it
