### PR TITLE
Fix yet more clutter spam

### DIFF
--- a/transmission-daemon@patapon.info/extension.js
+++ b/transmission-daemon@patapon.info/extension.js
@@ -428,9 +428,13 @@ const TransmissionDaemonIndicator = new Lang.Class({
         this.setMenu(menu);
 
         this.updateOptions();
-        gsettings.connect("changed", Lang.bind(this, function() {
+        let settingsId = gsettings.connect("changed", Lang.bind(this, function() {
             this.updateOptions();
             this.updateStats(true);
+        }));
+
+        this.connect("destroy", Lang.bind(null, function() {
+            gsettings.disconnect(settingsId);
         }));
 
         this.refreshControls(false);


### PR DESCRIPTION
The indicator connected a signal to the gsettings object, but
neglected to disconnect it on destroy, leading to tons of spam if the 
extension is disabled and re-enabled.
