### PR TITLE
Fixed wrong progress padding when seeding and ratio > 0

### DIFF
--- a/transmission-daemon@patapon.info/extension.js
+++ b/transmission-daemon@patapon.info/extension.js
@@ -1054,7 +1054,7 @@ const TransmissionTorrent = new Lang.Class({
                 break;
         }
         Clutter.cairo_set_source_color(cr, color);
-        cr.rectangle(27, 0, widthDownloaded, height);
+        cr.rectangle(padding, 0, widthDownloaded, height);
         Clutter.cairo_set_source_color(cr, color);
         cr.fillPreserve();
         cr.setLineWidth(borderWidth);
@@ -1074,7 +1074,7 @@ const TransmissionTorrent = new Lang.Class({
             color = uploadedColor;
             border_color = seedBorderColor;
             Clutter.cairo_set_source_color(cr, color);
-            cr.rectangle(0, 0, widthUploaded, height);
+            cr.rectangle(padding, 0, widthUploaded, height);
             Clutter.cairo_set_source_color(cr, color);
             cr.fillPreserve();
             cr.setLineWidth(borderWidth);


### PR DESCRIPTION
Just a simple fix to use global defined padding instead of 0. 

![transmission_shell_extension_progress_styles_bug](https://cloud.githubusercontent.com/assets/46217/18256312/d1964eec-73dd-11e6-95b6-7a801bdd0c05.png)
